### PR TITLE
US-10404: spdlog: use the safer snwprintf() instead of swprintf() on all platforms

### DIFF
--- a/include/spdlog/fmt/bundled/format-inl.h
+++ b/include/spdlog/fmt/bundled/format-inl.h
@@ -79,11 +79,8 @@ inline int fmt_snprintf(char *buffer, size_t size, const char *format, ...) {
 # define FMT_SNPRINTF fmt_snprintf
 #endif  // _MSC_VER
 
-#if defined(_WIN32) && defined(__MINGW32__) && !defined(__NO_ISOCEXT)
+// Don't use unbounded swprintf at all (unsafe), use snwprintf for all platforms instead
 # define FMT_SWPRINTF snwprintf
-#else
-# define FMT_SWPRINTF swprintf
-#endif // defined(_WIN32) && defined(__MINGW32__) && !defined(__NO_ISOCEXT)
 
 typedef void (*FormatFunc)(internal::buffer &, int, string_view);
 


### PR DESCRIPTION
Note that the change applies on top of the upstream v1.3.1 tag, not the whole v1.x branch.
