### PR TITLE
US-10404 Made splog compile on all platforms supported by You.i

### DIFF
--- a/include/spdlog/fmt/bundled/format-inl.h
+++ b/include/spdlog/fmt/bundled/format-inl.h
@@ -715,7 +715,19 @@ template <typename Double>
 FMT_FUNC typename std::enable_if<sizeof(Double) == sizeof(uint64_t), bool>::type
     grisu2_format(Double value, buffer &buf, core_format_specs specs) {
   FMT_ASSERT(value >= 0, "value is negative");
+
+#ifdef __ORBIS__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wfloat-equal"
+#endif
+
+  // zero has a stable/predictable representation in FP binary, so this should be fine
   if (value == 0) {
+
+#ifdef __ORBIS__
+#pragma clang diagnostic pop
+#endif
+
     gen_digits_params params = process_specs(specs, 1, buf);
     const size_t size = 1;
     buf[0] = '0';


### PR DESCRIPTION
- Tweaked conditional compilation to make PS4 use std::thread

The upstream spdlog code uses thr_self() API for BSD compilation.
Even though based on FreeBSD, PS4/Orbis platform does not provide the said API,
hence we need to fall back to std::thread usage instead.

According to the upstream developer's comment, std::thread facilities are not used
by default since its implementation (used to be) slow, at least on some platforms.

- Tweaked ifdefs to disable use of SetHandleInformation on UWP

- Switched to C11-compliant localtime_s and gmtime_s on Orbis

- F_SETFD and F_CLOEXEC are missing on Orbis and this block does not seem critical
for functionality and so was effectively switched off for Orbis targets.

- The tm::tm_gmtoff field is a BSD extension but it is missing on Orbis as well;
since the spdlog author already worked around this absence for Solaris targets,
this patch reuses the same approach

- isatty() is missing on Orbis but here we assume that there's no tty on PS4 anyway.

- we assume that there is no color support neeeded for Orbis log output

- there's a floating-point comparison with 0 that triggers warnings in our build;
since we're comparing with 0 that has a predictable binary representation,
the said warning is suppressed for that particular line.