### PR TITLE
US-10405 Made spdlog avoid non-existent tm::tm_gmtoff on Tizen

### DIFF
--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -280,7 +280,7 @@ inline int utc_minutes_offset(const std::tm &tm = details::os::localtime())
     return offset;
 #else
 
-#if defined(sun) || defined(__sun) || defined(_AIX) || defined(__ORBIS__)
+#if defined(sun) || defined(__sun) || defined(_AIX) || defined(__ORBIS__) || defined(__native_client__)
     // 'tm_gmtoff' field is BSD extension and it's missing on SunOS/Solaris
     struct helper
     {


### PR DESCRIPTION
I tried to implement a more reliable solution rather than relying on obscure ifdefs,
using SFINAE as suggested in many of the clever responses here:
https://stackoverflow.com/q/1005476/11947969

However, SFINAE substitution rules are applied only _after_ the syntax/name definition checks,
and compiler failed the "tm.tm_gmtoff" reference even though it was located in the "false"
template instance... :(

The two new macro names seem to be relatively reliable way to see if the BSD's GMT offset field extension
is actually present.