### PR TITLE
US-10405 Fixed spdlog dependency on stat64 for Tizen x86_64

### DIFF
--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -236,7 +236,7 @@ inline size_t filesize(FILE *f)
 #else // unix
     int fd = fileno(f);
 // 64 bits(but not in osx or cygwin, where fstat64 is deprecated)
-#if !defined(__FreeBSD__) && !defined(__APPLE__) && (defined(__x86_64__) || defined(__ppc64__)) && !defined(__CYGWIN__)
+#if !defined(__FreeBSD__) && !defined(__APPLE__) && (defined(__x86_64__) || defined(__ppc64__)) && !defined(__CYGWIN__) && !defined(__native_client__)
     struct stat64 st;
     if (fstat64(fd, &st) == 0)
     {


### PR DESCRIPTION
The Tizen x86_64 compiler toolchain does not define stat64/fstat64 even in 64-bit mode
(similar to Apple OSX, where these are deprecated since the stock stat/fstat accommodate 64-bit variants since OSX 10.6).

This adds an additional compile-time check to do the same fix for Tizen.
